### PR TITLE
Adapt to v4.13 API change: Id from Core to Utils

### DIFF
--- a/.github/workflows/build_qmake.yml
+++ b/.github/workflows/build_qmake.yml
@@ -4,7 +4,7 @@ on: [push]
 
 env:
   QT_VERSION: 5.14.2
-  QT_CREATOR_VERSION: 4.12.0
+  QT_CREATOR_VERSION: 4.13.0
   PLUGIN_PRO: doxygen.pro
   PLUGIN_NAME: Doxygen
 

--- a/.github/workflows/build_qmake.yml
+++ b/.github/workflows/build_qmake.yml
@@ -3,7 +3,7 @@ name: QMake Build Matrix
 on: [push]
 
 env:
-  QT_VERSION: 5.14.2
+  QT_VERSION: 5.15.1
   QT_CREATOR_VERSION: 4.13.0
   PLUGIN_PRO: doxygen.pro
   PLUGIN_NAME: Doxygen

--- a/doxygen.cpp
+++ b/doxygen.cpp
@@ -577,7 +577,7 @@ uint Doxygen::documentProject(ProjectExplorer::Project* p, const DoxygenSettings
                     && fileExtension == "qml"
                     )
                 ) {*/
-            Core::IEditor* editor = editorManager->openEditor(files[i], Core::Id(),
+            Core::IEditor* editor = editorManager->openEditor(files[i], Utils::Id(),
                 Core::EditorManager::DoNotChangeCurrentEditor
                     | Core::EditorManager::IgnoreNavigationHistory
                     | Core::EditorManager::DoNotMakeVisible);

--- a/doxygenplugin.cpp
+++ b/doxygenplugin.cpp
@@ -111,7 +111,7 @@ bool DoxygenPlugin::initialize(const QStringList& arguments, QString* errorStrin
     Core::Context globalcontext(C_GLOBAL);
     //Core::Context context(CMD_ID_DOXYGEN_MAINVIEW);
     Core::ActionContainer* toolsContainer = am->actionContainer(Core::Constants::M_TOOLS);
-    Core::ActionContainer* doxygenMenu = am->createMenu(Core::Id(CMD_ID_DOXYGEN_MENU));
+    Core::ActionContainer* doxygenMenu = am->createMenu(Utils::Id(CMD_ID_DOXYGEN_MENU));
     doxygenMenu->menu()->setTitle(tr("&Doxygen"));
     toolsContainer->addMenu(doxygenMenu);
 

--- a/doxygensettings.cpp
+++ b/doxygensettings.cpp
@@ -39,7 +39,7 @@ namespace Internal {
             m_settings.fromSettings(settings);
         setId("A.General");
         setDisplayName(tr("Doxygen"));
-        setCategory(Core::Id::fromString(QString(Constants::DOXYGEN_SETTINGS_CATEGORY)));
+        setCategory(Utils::Id::fromString(QString(Constants::DOXYGEN_SETTINGS_CATEGORY)));
         setDisplayCategory("Doxygen");
         setCategoryIcon(Utils::Icon(":/doxygen.png"));
     }


### PR DESCRIPTION
The plugin wasn't compiling. Examining the issue, i noticed the API change regarding `Core::Id` in this commit:
[1b431fe271e04b111d475654c7ea003981cba989](https://github.com/qt-creator/qt-creator/commit/1b431fe271e04b111d475654c7ea003981cba989)

This PR only addresses that particular change. I did not check the impact of the other changes in QtCreator v4.13.