### PR TITLE
Rearrange Settings Form

### DIFF
--- a/doxygensettingswidget.ui
+++ b/doxygensettingswidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>700</width>
-    <height>450</height>
+    <width>1606</width>
+    <height>1178</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,12 +20,6 @@
    <size>
     <width>650</width>
     <height>450</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>750</width>
-    <height>550</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -43,13 +37,25 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>200</height>
+      </size>
+     </property>
      <property name="title">
       <string>Doxygen Configuration</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
      </property>
      <property name="checkable">
       <bool>false</bool>
      </property>
      <layout class="QFormLayout" name="commandsLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMinimumSize</enum>
+      </property>
       <property name="fieldGrowthPolicy">
        <enum>QFormLayout::ExpandingFieldsGrow</enum>
       </property>
@@ -123,169 +129,202 @@
      </property>
      <layout class="QHBoxLayout" name="bottomHorizontalLayout">
       <item>
-       <layout class="QFormLayout" name="formLayout_3">
-        <property name="fieldGrowthPolicy">
-         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,1">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetDefaultConstraint</enum>
         </property>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_style">
-          <property name="text">
-           <string>Comments style:</string>
+        <item>
+         <layout class="QFormLayout" name="formLayout_3">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetMinimumSize</enum>
           </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QComboBox" name="styleChooser">
-          <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
           </property>
-          <item>
-           <property name="text">
-            <string>JavaDoc</string>
-           </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_style">
+            <property name="text">
+             <string>Comments style:</string>
+            </property>
+           </widget>
           </item>
-          <item>
-           <property name="text">
-            <string>Qt</string>
-           </property>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="styleChooser">
+            <property name="sizeAdjustPolicy">
+             <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
+            </property>
+            <item>
+             <property name="text">
+              <string>JavaDoc</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Qt</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Custom</string>
+             </property>
+            </item>
+           </widget>
           </item>
-          <item>
-           <property name="text">
-            <string>Custom</string>
-           </property>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_fcomment">
+            <property name="text">
+             <string>Files to comment:</string>
+            </property>
+           </widget>
           </item>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_fcomment">
-          <property name="text">
-           <string>Files to comment:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QComboBox" name="fcommentChooser">
-          <item>
-           <property name="text">
-            <string>Headers</string>
-           </property>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="fcommentChooser">
+            <item>
+             <property name="text">
+              <string>Headers</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Implementations</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>All</string>
+             </property>
+            </item>
+           </widget>
           </item>
-          <item>
-           <property name="text">
-            <string>Implementations</string>
-           </property>
+         </layout>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="formLayout_5">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetDefaultConstraint</enum>
+          </property>
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::FieldsStayAtSizeHint</enum>
+          </property>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="printBriefTag">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
           </item>
-          <item>
-           <property name="text">
-            <string>All</string>
-           </property>
+          <item row="0" column="1">
+           <widget class="QLabel" name="label_printBriefTag">
+            <property name="text">
+             <string>Print brief tag</string>
+            </property>
+           </widget>
           </item>
-         </widget>
+         </layout>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_printBriefTag">
-          <property name="text">
-           <string>Print brief tag</string>
+        <item>
+         <layout class="QFormLayout" name="formLayout_4">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
           </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QCheckBox" name="printBriefTag">
-          <property name="text">
-           <string/>
+          <property name="labelAlignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
           </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_shortVariableDoc">
-          <property name="text">
-           <string>Short Variable documentation: </string>
+          <property name="formAlignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
           </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QCheckBox" name="shortVariableDoc">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_verbosePrinting">
-          <property name="text">
-           <string>Verbose (fn, var, class file...): </string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1">
-         <widget class="QCheckBox" name="verbosePrinting">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0">
-         <widget class="QLabel" name="label_filecomment">
-          <property name="text">
-           <string>Comment files</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="1">
-         <widget class="QCheckBox" name="fileComments">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="0">
-         <widget class="QLabel" name="label_filecommentHeaders">
-          <property name="text">
-           <string>Comment headers</string>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="1">
-         <widget class="QCheckBox" name="commentHeaderFiles">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="11" column="0">
-         <widget class="QLabel" name="label_filecommentImpl">
-          <property name="text">
-           <string>Comment implementation</string>
-          </property>
-         </widget>
-        </item>
-        <item row="11" column="1">
-         <widget class="QCheckBox" name="commentImplementationFiles">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="0">
-         <widget class="QLabel" name="label_addreturntype">
-          <property name="text">
-           <string>Automatically add return type: </string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="1">
-         <widget class="QCheckBox" name="autoAddReturnTypes">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
+          <item row="0" column="1">
+           <widget class="QLabel" name="label_shortVariableDoc">
+            <property name="text">
+             <string>Short Variable documentation: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="shortVariableDoc">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="label_verbosePrinting">
+            <property name="text">
+             <string>Verbose (fn, var, class file...): </string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="verbosePrinting">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="label_addreturntype">
+            <property name="text">
+             <string>Automatically add return type: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="autoAddReturnTypes">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLabel" name="label_filecomment">
+            <property name="text">
+             <string>Comment files</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="fileComments">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLabel" name="label_filecommentHeaders">
+            <property name="text">
+             <string>Comment headers</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QCheckBox" name="commentHeaderFiles">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLabel" name="label_filecommentImpl">
+            <property name="text">
+             <string>Comment implementation</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QCheckBox" name="commentImplementationFiles">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>
       <item>
        <widget class="QTabWidget" name="tabCustomSettings">
         <property name="currentIndex">
-         <number>0</number>
+         <number>1</number>
         </property>
         <widget class="QWidget" name="fileCommentSettings">
          <attribute name="title">


### PR DESCRIPTION
On my 4k monitor the current settings form did not look as nice as on conventional HD monitors, that's why i removed the maximum size flags.

Moreover, the check boxes switched places with their respective labels conforming with other menus.

Summary:
* Check boxes in front of Labels, as other Options menus
* lift maximum width of the form (for high res screens)
* Show custom options panel